### PR TITLE
refactor: migrate from requests to httpx for thread-safe sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "click>=8.0",
     "loguru>=0.7",
     "pydantic>=2.0",
-    "requests>=2.28",
+    "httpx>=0.27",
     "browser-cookie3>=0.19",
     "google-genai",
 ]

--- a/skipera/assessment/solver.py
+++ b/skipera/assessment/solver.py
@@ -3,7 +3,7 @@ import os
 import json
 from datetime import datetime, timezone
 
-import requests
+import httpx
 
 from .. import config
 from .types import QUESTION_TYPE_MAP, MODEL_MAP, deep_blank_model, WHITELISTED_QUESTION_TYPES
@@ -43,8 +43,8 @@ TYPE_LOOKUP = {
 
 
 class GradedSolver(object):
-    def __init__(self, session: requests.Session, course_id: str, item_id: str):
-        self.session: requests.Session = session
+    def __init__(self, session: httpx.Client, course_id: str, item_id: str):
+        self.session: httpx.Client = session
         self.course_id: str = course_id
         self.item_id: str = item_id
         self.attempt_id = None

--- a/skipera/coach/solver.py
+++ b/skipera/coach/solver.py
@@ -1,11 +1,11 @@
-import requests
+import httpx
 from loguru import logger
 from .. import config
 from ..session_utils import get_csrf_headers
 
 
 class CoachSolver(object):
-    def __init__(self, session: requests.Session, user_id: str, course_id: str, item_id: str):
+    def __init__(self, session: httpx.Client, user_id: str, course_id: str, item_id: str):
         self.session = session
         self.user_id = user_id
         self.course_id = course_id

--- a/skipera/discussion/solver.py
+++ b/skipera/discussion/solver.py
@@ -1,7 +1,7 @@
 from html import escape
 from html.parser import HTMLParser
 
-import requests
+import httpx
 from loguru import logger
 
 from .. import config
@@ -44,8 +44,8 @@ class CMLTextParser(HTMLParser):
 
 
 class DiscussionPromptSolver(object):
-    def __init__(self, session: requests.Session, user_id: str, course_id: str, item_id: str):
-        self.session: requests.Session = session
+    def __init__(self, session: httpx.Client, user_id: str, course_id: str, item_id: str):
+        self.session: httpx.Client = session
         self.user_id: str = user_id
         self.course_id: str = course_id
         self.item_id: str = item_id

--- a/skipera/llm/connector.py
+++ b/skipera/llm/connector.py
@@ -1,5 +1,5 @@
 import json
-import requests
+import httpx
 from ..config import (PERPLEXITY_API_URL, PERPLEXITY_API_KEY,
                       PERPLEXITY_MODEL, GEMINI_API_KEY, GEMINI_MODEL)
 from google import genai
@@ -52,9 +52,9 @@ class PerplexityConnector(object):
                 "json_schema": {"schema": response_schema}
             }
 
-        response = requests.post(url=self.API_URL, headers={
+        response = httpx.post(url=self.API_URL, headers={
             "Authorization": f"Bearer {self.API_KEY}"
-        }, json=payload).json()
+        }, json=payload, timeout=60.0).json()
 
         content = response["choices"][0]["message"]["content"]
         if response_schema is not None:

--- a/skipera/main.py
+++ b/skipera/main.py
@@ -1,5 +1,5 @@
 import click
-import requests
+import httpx
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from .config import fetch_browser_cookies, CONFIG_FILE, DEFAULT_CONFIG, BASE_URL, HEADERS, COOKIES
 import json
@@ -16,7 +16,7 @@ class Skipera(object):
         self.user_id = None
         self.course_id = None
         self.base_url = BASE_URL
-        self.session = requests.Session()
+        self.session = httpx.Client(timeout=60.0, follow_redirects=True)
         self.session.headers.update(HEADERS)
         self.session.cookies.update(COOKIES)
         self.course = course

--- a/skipera/session_utils.py
+++ b/skipera/session_utils.py
@@ -1,7 +1,7 @@
 import random
 import time
 
-import requests
+import httpx
 
 _CSRF_COOKIE_MAP = {
     "CSRF3-Token": "x-csrf3-token",
@@ -10,7 +10,7 @@ _CSRF_COOKIE_MAP = {
 }
 
 
-def get_csrf_headers(session: requests.Session) -> dict[str, str]:
+def get_csrf_headers(session: httpx.Client) -> dict[str, str]:
     """Read CSRF tokens from session cookies and return them as per-request headers."""
     headers = {}
     for cookie_name, header_name in _CSRF_COOKIE_MAP.items():

--- a/skipera/watcher/watch.py
+++ b/skipera/watcher/watch.py
@@ -1,4 +1,3 @@
-# https://github.com/serv0id/skipera
 import httpx
 from loguru import logger
 from .. import config

--- a/skipera/watcher/watch.py
+++ b/skipera/watcher/watch.py
@@ -1,12 +1,12 @@
 # https://github.com/serv0id/skipera
-import requests
+import httpx
 from loguru import logger
 from .. import config
 from ..session_utils import get_csrf_headers, random_delay
 
 
 class Watcher(object):
-    def __init__(self, session: requests.Session, item: dict, metadata: dict, user_id: str, slug: str, course_id: str):
+    def __init__(self, session: httpx.Client, item: dict, metadata: dict, user_id: str, slug: str, course_id: str):
         self.metadata = metadata
         self.session = session
         self.item = item


### PR DESCRIPTION
## Summary

- Replace `requests.Session` with `httpx.Client` across the codebase. The HTTP session is now passed into per-thread solvers from `process_items()`, which fans out via `ThreadPoolExecutor`. `requests.Session` is not safe for concurrent use; `httpx.Client` is.
- API surface is near-identical (`get` / `post` / `put`, `.headers.update`, `.cookies.update`, `.json()`, `.status_code`, `.text`), so call sites are unchanged.
- Two behavior diffs pinned explicitly on the client to preserve previous defaults:
  - `timeout=60.0` — httpx default is 5s, requests was None
  - `follow_redirects=True` — httpx default is False, requests was True
- One-shot `requests.post(...)` for Perplexity in `llm/connector.py` becomes `httpx.post(..., timeout=60.0)`.
- `pyproject.toml`: `requests>=2.28` → `httpx>=0.27`.

## Test plan

- [x] `pip install -e .` succeeds in a fresh venv
- [x] `python -c "import skipera.main"` imports cleanly
- [x] `skipera --help` runs
- [x] Run `skipera <slug>` (non-LLM) on a course and confirm videos/coach items complete
- [x] Run `skipera <slug> --llm` and confirm at least one assessment passes
- [x] Confirm no `TypeError` from removed `requests.Session` type hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)